### PR TITLE
Fix mobile responsiveness

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -5,7 +5,7 @@ const sections = [
   { name: 'HACKATHONS', id: 'hackathons' },
 ];
 ---
-<nav class="border-b border-black bg-concrete sticky top-0 z-50 px-4 py-3">
+<nav class="border-b border-black bg-concrete sticky top-0 z-50 px-2 sm:px-4 py-3">
   <div class="max-w-7xl mx-auto flex flex-wrap items-center justify-between gap-2">
     <div class="flex flex-wrap items-center gap-1">
       <a href="/" class="btn-brutal text-[10px] py-1 px-3">HOME</a>

--- a/src/layouts/BlogPostLayout.astro
+++ b/src/layouts/BlogPostLayout.astro
@@ -8,9 +8,9 @@ const formattedDate = new Date(pubDate).toISOString().split('T')[0];
 ---
 <BaseLayout title={`${title} | Rasha Hantash`} description={description}>
   <Nav />
-  <div class="max-w-3xl mx-auto px-2 sm:px-4 py-8 sm:py-12 overflow-x-hidden">
+  <div class="max-w-3xl mx-auto px-2 sm:px-4 py-8 sm:py-12 w-full min-w-0 overflow-hidden">
 
-    <article class="grid-cell bracket-corners bracket-corners-bottom mt-6" style="overflow-x: hidden;">
+    <article class="grid-cell bracket-corners bracket-corners-bottom mt-6 min-w-0 overflow-hidden">
       <!-- Metadata -->
       <div class="mb-6 border-b border-black pb-4">
         <p class="section-label mb-1">PUBLISHED {formattedDate}</p>
@@ -25,7 +25,7 @@ const formattedDate = new Date(pubDate).toISOString().split('T')[0];
       </div>
 
       <!-- Content -->
-      <div class="prose-brutal">
+      <div class="prose-brutal min-w-0">
         <slot />
       </div>
     </article>
@@ -89,13 +89,13 @@ const formattedDate = new Date(pubDate).toISOString().split('T')[0];
     text-decoration: none;
   }
   .prose-brutal :global(table) {
-    width: 100%;
     border-collapse: collapse;
     margin: 1rem 0;
     font-size: 12px;
     display: block;
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
+    max-width: 100%;
   }
   .prose-brutal :global(th),
   .prose-brutal :global(td) {

--- a/src/layouts/BlogPostLayout.astro
+++ b/src/layouts/BlogPostLayout.astro
@@ -8,13 +8,13 @@ const formattedDate = new Date(pubDate).toISOString().split('T')[0];
 ---
 <BaseLayout title={`${title} | Rasha Hantash`} description={description}>
   <Nav />
-  <div class="max-w-3xl mx-auto px-4 py-12">
+  <div class="max-w-3xl mx-auto px-2 sm:px-4 py-8 sm:py-12 overflow-x-hidden">
 
-    <article class="grid-cell bracket-corners bracket-corners-bottom mt-6">
+    <article class="grid-cell bracket-corners bracket-corners-bottom mt-6" style="overflow-x: hidden;">
       <!-- Metadata -->
       <div class="mb-6 border-b border-black pb-4">
         <p class="section-label mb-1">PUBLISHED {formattedDate}</p>
-        <h1 class="text-2xl font-bold uppercase tracking-wide">{title}</h1>
+        <h1 class="text-lg sm:text-2xl font-bold uppercase tracking-wide">{title}</h1>
         {tags.length > 0 && (
           <div class="flex flex-wrap gap-2 mt-3">
             {tags.map((tag: string) => (
@@ -68,8 +68,9 @@ const formattedDate = new Date(pubDate).toISOString().split('T')[0];
   .prose-brutal :global(code:not(pre code)) {
     background-color: rgba(0, 0, 0, 0.08);
     padding: 2px 6px;
-    font-size: 13px;
+    font-size: 12px;
     border: 1px solid rgba(0, 0, 0, 0.15);
+    word-break: break-all;
   }
   .prose-brutal :global(blockquote) {
     border-left: 3px solid var(--accent);
@@ -91,15 +92,28 @@ const formattedDate = new Date(pubDate).toISOString().split('T')[0];
     width: 100%;
     border-collapse: collapse;
     margin: 1rem 0;
+    font-size: 12px;
+    display: block;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
   }
   .prose-brutal :global(th),
   .prose-brutal :global(td) {
-    padding: 0.5rem 1rem;
+    padding: 0.35rem 0.5rem;
     border: 1px solid rgba(0, 0, 0, 0.2);
     text-align: left;
   }
   .prose-brutal :global(th) {
     font-weight: 700;
     background-color: rgba(0, 0, 0, 0.05);
+  }
+  @media (min-width: 640px) {
+    .prose-brutal :global(table) {
+      font-size: 14px;
+    }
+    .prose-brutal :global(th),
+    .prose-brutal :global(td) {
+      padding: 0.5rem 1rem;
+    }
   }
 </style>

--- a/src/styles/brutalist.css
+++ b/src/styles/brutalist.css
@@ -1,9 +1,15 @@
 /* Grid Cell */
 .grid-cell {
   border: 1px solid var(--border);
-  padding: 1.5rem;
+  padding: 0.75rem;
   position: relative;
   transition: background-color 0.15s ease;
+}
+
+@media (min-width: 640px) {
+  .grid-cell {
+    padding: 1.5rem;
+  }
 }
 
 .grid-cell:hover {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -26,6 +26,7 @@ body {
   font-size: 14px;
   line-height: 1.6;
   -webkit-font-smoothing: antialiased;
+  overflow-x: hidden;
 }
 
 ::selection {
@@ -45,6 +46,7 @@ pre.astro-code {
   overflow-x: auto;
   font-size: 13px;
   line-height: 1.5;
+  max-width: 100%;
 }
 
 code {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -17,6 +17,7 @@
 
 html {
   scroll-behavior: smooth;
+  overflow-x: hidden;
 }
 
 body {
@@ -27,6 +28,8 @@ body {
   line-height: 1.6;
   -webkit-font-smoothing: antialiased;
   overflow-x: hidden;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
 }
 
 ::selection {
@@ -46,7 +49,13 @@ pre.astro-code {
   overflow-x: auto;
   font-size: 13px;
   line-height: 1.5;
-  max-width: 100%;
+  max-width: calc(100vw - 2rem);
+}
+
+@media (min-width: 640px) {
+  pre.astro-code {
+    max-width: 100%;
+  }
 }
 
 code {


### PR DESCRIPTION
## Summary
- Prevent horizontal overflow on mobile (body `overflow-x: hidden`)
- Reduce `grid-cell` padding from 1.5rem to 0.75rem on mobile (restores at sm breakpoint)
- Reduce blog container padding (`px-2` on mobile, `px-4` at sm)
- Tables scroll horizontally on mobile with smaller font/padding
- Blog post title scales down on mobile (`text-lg` -> `text-2xl` at sm)
- Inline code uses `word-break: break-all` to prevent overflow
- Code blocks get `max-width: 100%`

## Test plan
- [ ] Check blog article on iPhone 12 (390px) — no horizontal clipping
- [ ] Verify tables are scrollable on mobile
- [ ] Verify code blocks don't overflow
- [ ] Check homepage grid cells have comfortable padding on mobile
- [ ] Desktop layout unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)