### PR TITLE
Replace bracket corners with + markers

### DIFF
--- a/src/styles/brutalist.css
+++ b/src/styles/brutalist.css
@@ -16,32 +16,33 @@
   background-color: rgba(255, 69, 0, 0.06);
 }
 
-/* Bracket Corners */
+/* Bracket Corners — hidden on mobile, shown on sm+ */
 .bracket-corners {
   position: relative;
 }
 
 .bracket-corners::before,
 .bracket-corners::after {
+  content: '';
   position: absolute;
-  color: var(--accent);
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 14px;
-  font-weight: 700;
-  line-height: 1;
+  width: 20px;
+  height: 20px;
+  border-color: var(--accent);
+  border-style: solid;
   pointer-events: none;
+  display: none;
 }
 
 .bracket-corners::before {
-  content: '+';
-  top: -7px;
-  left: -3px;
+  top: -1px;
+  left: -1px;
+  border-width: 2px 0 0 2px;
 }
 
 .bracket-corners::after {
-  content: '+';
-  top: -7px;
-  right: -3px;
+  top: -1px;
+  right: -1px;
+  border-width: 2px 2px 0 0;
 }
 
 .bracket-corners-bottom {
@@ -50,25 +51,35 @@
 
 .bracket-corners-bottom::before,
 .bracket-corners-bottom::after {
+  content: '';
   position: absolute;
-  color: var(--accent);
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 14px;
-  font-weight: 700;
-  line-height: 1;
+  width: 20px;
+  height: 20px;
+  border-color: var(--accent);
+  border-style: solid;
   pointer-events: none;
+  display: none;
 }
 
 .bracket-corners-bottom::before {
-  content: '+';
-  bottom: -7px;
-  left: -3px;
+  bottom: -1px;
+  left: -1px;
+  border-width: 0 0 2px 2px;
 }
 
 .bracket-corners-bottom::after {
-  content: '+';
-  bottom: -7px;
-  right: -3px;
+  bottom: -1px;
+  right: -1px;
+  border-width: 0 2px 2px 0;
+}
+
+@media (min-width: 640px) {
+  .bracket-corners::before,
+  .bracket-corners::after,
+  .bracket-corners-bottom::before,
+  .bracket-corners-bottom::after {
+    display: block;
+  }
 }
 
 /* Crosshair Marker */

--- a/src/styles/brutalist.css
+++ b/src/styles/brutalist.css
@@ -23,25 +23,25 @@
 
 .bracket-corners::before,
 .bracket-corners::after {
-  content: '';
   position: absolute;
-  width: 20px;
-  height: 20px;
-  border-color: var(--accent);
-  border-style: solid;
+  color: var(--accent);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1;
   pointer-events: none;
 }
 
 .bracket-corners::before {
-  top: -1px;
-  left: -1px;
-  border-width: 2px 0 0 2px;
+  content: '+';
+  top: -7px;
+  left: -3px;
 }
 
 .bracket-corners::after {
-  top: -1px;
-  right: -1px;
-  border-width: 2px 2px 0 0;
+  content: '+';
+  top: -7px;
+  right: -3px;
 }
 
 .bracket-corners-bottom {
@@ -50,25 +50,25 @@
 
 .bracket-corners-bottom::before,
 .bracket-corners-bottom::after {
-  content: '';
   position: absolute;
-  width: 20px;
-  height: 20px;
-  border-color: var(--accent);
-  border-style: solid;
+  color: var(--accent);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1;
   pointer-events: none;
 }
 
 .bracket-corners-bottom::before {
-  bottom: -1px;
-  left: -1px;
-  border-width: 0 0 2px 2px;
+  content: '+';
+  bottom: -7px;
+  left: -3px;
 }
 
 .bracket-corners-bottom::after {
-  bottom: -1px;
-  right: -1px;
-  border-width: 0 2px 2px 0;
+  content: '+';
+  bottom: -7px;
+  right: -3px;
 }
 
 /* Crosshair Marker */


### PR DESCRIPTION
## Summary
- Replace L-shaped orange border corners with small `+` signs at each corner
- The border corners were overlapping the "PUBLISHED" text on mobile
- The `+` markers are smaller, don't interfere with content, and keep the brutalist aesthetic

## Test plan
- [ ] Verify `+` markers appear at all four corners of blog article on mobile
- [ ] Verify `+` markers appear on desktop too
- [ ] Check that "PUBLISHED" text is no longer obscured

🤖 Generated with [Claude Code](https://claude.com/claude-code)