### PR TITLE
Add Vercel Web Analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@astrojs/tailwind": "^6.0.2",
         "@fontsource-variable/inter": "^5.0.0",
         "@fontsource/jetbrains-mono": "^5.0.0",
+        "@vercel/analytics": "^2.0.1",
         "astro": "^5.2.0",
         "tailwindcss": "^3.4.0"
       }
@@ -1636,6 +1637,48 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/acorn": {
       "version": "8.15.0",

--- a/package.json
+++ b/package.json
@@ -9,10 +9,11 @@
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^5.2.0",
     "@astrojs/tailwind": "^6.0.2",
-    "tailwindcss": "^3.4.0",
     "@fontsource-variable/inter": "^5.0.0",
-    "@fontsource/jetbrains-mono": "^5.0.0"
+    "@fontsource/jetbrains-mono": "^5.0.0",
+    "@vercel/analytics": "^2.0.1",
+    "astro": "^5.2.0",
+    "tailwindcss": "^3.4.0"
   }
 }

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -2,6 +2,7 @@
 import '@fontsource-variable/inter';
 import '@fontsource/jetbrains-mono/400.css';
 import '../styles/global.css';
+import Analytics from '@vercel/analytics/astro';
 
 interface Props {
   title?: string;
@@ -23,5 +24,6 @@ const { title = 'Rasha Hantash', description = 'Senior Software Engineer' } = As
   </head>
   <body class="min-h-screen flex flex-col bg-cream text-ink">
     <slot />
+    <Analytics />
   </body>
 </html>


### PR DESCRIPTION
Mounts <Analytics /> in BaseLayout so the /_vercel/insights/script tag
loads on every page. Production-only by default — dev pages stay silent.
No cookie banner required (Vercel Web Analytics is cookieless).

Verified the script is injected by running 'npm run build' and grepping
the emitted HTML for /_vercel/insights/script.