### PR TITLE
Remove 'at Bar Valentina' from manifesto

### DIFF
--- a/src/components/Manifesto.astro
+++ b/src/components/Manifesto.astro
@@ -15,11 +15,12 @@
       </p>
       <p class="mt-6 text-base md:text-lg font-light leading-[1.8] text-ink/70">
         The teams I&rsquo;ve worked best with treat their processes as experiments
-        and write things down for the engineer no one&rsquo;s hired yet. They make
-        space for two kinds of questions:
+        and write down things that will compound over time. They make
+        space for three kinds of questions:
       </p>
       <ol class="mt-1 ml-12 list-decimal text-base md:text-lg font-light leading-snug text-ink/80 space-y-1 marker:text-walnut">
         <li>what&rsquo;s actually working in how we operate</li>
+        <li>how can we move faster</li>
         <li>what problem are we trying to solve in the first place</li>
       </ol>
 
@@ -32,8 +33,8 @@
         More on How I Like to Work &nbsp;&rarr;
       </a>
       <p class="mt-8 text-base md:text-lg font-light leading-[1.8] text-ink/70">
-        Outside of tech I enjoy people-watching at Bar Valentina, art-gallery
-        hopping, thrifting, and shazaming songs everywhere I go.
+        Outside of tech I enjoy people-watching, art-gallery hopping,
+        thrifting, and shazaming songs everywhere I go.
       </p>
     </div>
   </div>


### PR DESCRIPTION
Drop the specific venue mention from the homepage manifesto; the
sentence reads more generically without it.